### PR TITLE
Remove filters from mdCollections in order to let more tests run

### DIFF
--- a/src/components/MetadataCollections/CollectionInfo/CollectionInfoView.js
+++ b/src/components/MetadataCollections/CollectionInfo/CollectionInfoView.js
@@ -3,9 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
-
 import {
-  Headline,
   KeyValue,
   List,
   Row,
@@ -13,8 +11,6 @@ import {
 
 import SelectUnselect from './SelectUnselect';
 import urls from '../../DisplayUtils/urls';
-
-import BasicCss from '../../BasicStyle.css';
 
 class CollectionInfoView extends React.Component {
   static propTypes = {
@@ -93,17 +89,6 @@ class CollectionInfoView extends React.Component {
               label={<FormattedMessage id="ui-finc-select.collection.permitted" />}
               value={_.get(metadataCollection, 'permitted', '-')}
             />
-          </Row>
-          <Row>
-            <Headline
-              size="medium"
-              className={BasicCss.styleForHeadline}
-            >
-              <FormattedMessage id="ui-finc-select.collection.filters" />
-            </Headline>
-          </Row>
-          <Row>
-            { this.renderList('filters') }
           </Row>
           <Row>
             <this.connectedSelectUnselect

--- a/src/components/MetadataCollections/MetadataCollections.js
+++ b/src/components/MetadataCollections/MetadataCollections.js
@@ -92,11 +92,9 @@ class MetadataCollections extends React.Component {
 
   resultsFormatter = {
     label: collection => collection.label,
-    // mdSource: collection => collection.mdSource.name,
     mdSource: collection => _.get(collection, 'mdSource.name', '-'),
     permitted: collection => collection.permitted,
     selected: collection => collection.selected,
-    filters: collection => collection.filters.join('; '),
     freeContent: collection => collection.freeContent,
   };
 
@@ -372,7 +370,6 @@ class MetadataCollections extends React.Component {
                         mdSource: intl.formatMessage({ id: 'ui-finc-select.collection.mdSource' }),
                         permitted: intl.formatMessage({ id: 'ui-finc-select.collection.permitted' }),
                         selected: intl.formatMessage({ id: 'ui-finc-select.collection.selected' }),
-                        filters: intl.formatMessage({ id: 'ui-finc-select.collection.filters' }),
                         freeContent: intl.formatMessage({ id: 'ui-finc-select.collection.freeContent' })
                       }}
                       contentData={this.props.contentData}

--- a/test/bigtest/network/factories/finc-select-metadata-collection.js
+++ b/test/bigtest/network/factories/finc-select-metadata-collection.js
@@ -6,10 +6,10 @@ export default Factory.extend({
   id: () => faker.random.uuid(),
   label: (i) => 'COLLECTION ' + i,
   description: (i) => 'description' + i,
-  // mdSource: {
-  //   id: 'mdSource id',
-  //   name: 'mdSource name'
-  // },
+  mdSource: {
+    id: 'uuid-1234',
+    name: 'mdSource name'
+  },
   metadataAvailable: '',
   usageRestricted: '',
   permitted: '',


### PR DESCRIPTION
I realized that `yarn test` (resp. `stripes test karma`) executed only 5 tests out of 63. When rendering metadata collections tests failed silently and were not executed.

This PR fixes the issue by removing filters from metadata collections.
Initially, it was planned that the filters were referenced by the metadata collections. However, we implemented it the other way around, that the metadata collections are referenced by the filters. I suspect rendering the filters in the metadata collections was an artifact that was not removed when finally implementing the filters.

As there are some open PRs dealing with tests ([PR-143](https://github.com/folio-org/ui-finc-select/pull/143) and [PR-123](https://github.com/folio-org/ui-finc-select/pull/132)) I propose to fix the correct execution of tests first.