### PR TITLE
UIFC-224: Set operator to '=' for selected filter

### DIFF
--- a/src/components/MetadataSources/filterConfigData.js
+++ b/src/components/MetadataSources/filterConfigData.js
@@ -16,6 +16,7 @@ const filterConfig = [
   {
     name: 'selected',
     cql: 'selected',
+    operator: '=',
     values: [
       { name: <FormattedMessage id="ui-finc-select.dataOption.all" />, cql: 'all' },
       { name: <FormattedMessage id="ui-finc-select.dataOption.some" />, cql: 'some' },


### PR DESCRIPTION
stripes-components changed the filter search cql syntax to use == and not = (STCOM-492). This breaks the selected filter of metadata sources.

This PR changes the operator of the selected filter to use '='.

Refs https://issues.folio.org/browse/UIFC-224
