### PR TITLE
UIFC-225: Set operator to '=' for selected and permitted filters

### DIFF
--- a/src/components/MetadataCollections/filterConfigData.js
+++ b/src/components/MetadataCollections/filterConfigData.js
@@ -5,6 +5,7 @@ const filterConfig = [
   {
     name: 'selected',
     cql: 'selected',
+    operator: '=',
     values: [
       { name: <FormattedMessage id="ui-finc-select.dataOption.yes" />, cql: 'yes' },
       { name: <FormattedMessage id="ui-finc-select.dataOption.no" />, cql: 'no' }
@@ -22,6 +23,7 @@ const filterConfig = [
   {
     name: 'permitted',
     cql: 'permitted',
+    operator: '=',
     values: [
       { name: <FormattedMessage id="ui-finc-select.dataOption.yes" />, cql: 'yes' },
       { name: <FormattedMessage id="ui-finc-select.dataOption.no" />, cql: 'no' }


### PR DESCRIPTION
stripes-components changed the filter search cql syntax to use == and not = (STCOM-492). This breaks the selected and permitted filters of metadata collections.

This PR changes the operator of the selected and permitted filters to use '='.

Refs https://issues.folio.org/browse/UIFC-225