### PR TITLE
UIFC-413: Migrate react-intl to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change history for ui-finc-select
 
-## 7.1.0 (IN PROGRESS)
+## 8.0.0 (IN PROGRESS)
 * Restructure localStorage, simplify urls for ShowCollections ([UIFC-370](https://folio-org.atlassian.net/browse/UIFC-370))
 * Restructure tests, add tests for SASQ ([UIFC-399](https://folio-org.atlassian.net/browse/UIFC-399))
 * Refactor FileUploaderField ([UIFC-372](https://folio-org.atlassian.net/browse/UIFC-372))
 * Adapt tests for index.js and add tests for routes ([UIFC-403](https://folio-org.atlassian.net/browse/UIFC-403))
+* Migrate react-intl to v7 ([UIFC-413](https://folio-org.atlassian.net/browse/UIFC-413))
 
 ## [7.0.0](https://github.com/folio-org/ui-finc-select/tree/v7.0.0) (2024-11-04)
 * Use functional components instead of class components ([UIFC-360](https://folio-org.atlassian.net/browse/UIFC-360))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/finc-select",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "description for finc-select-app",
   "main": "src/index.js",
   "repository": "folio-org/ui-finc-select",
@@ -12,7 +12,7 @@
     "test:jest": "jest --ci --coverage",
     "lint": "eslint src",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-finc-select ./translations/ui-finc-select/compiled"
+    "formatjs-compile": "stripes translate compil"
   },
   "devDependencies": {
     "@babel/core": "^7.11.0",
@@ -25,12 +25,11 @@
     "@folio/stripes-core": "^10.2.2",
     "@folio/stripes-final-form": "^8.1.0",
     "@folio/stripes-smart-components": "^9.2.2",
-    "@formatjs/cli": "^6.1.3",
     "eslint": "^7.32.0",
     "history": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   },
   "dependencies": {
@@ -50,7 +49,7 @@
     "@folio/stripes": "^9.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIFC-413

- update react-intl to v7
- remove @formatjs/cli; stripes-cli has it built-in

Refs [STRIPES-960](https://folio-org.atlassian.net/browse/STRIPES-960)